### PR TITLE
Expanded Module Page, Back Button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import {
   MessageWall,
   Modules,
   Calendar,
+  ExpandedModule,
 } from './pages';
 
 import NavBar from './components/NavBar';
@@ -20,6 +21,7 @@ function App() {
         <Route path="/example" element={(<Example />)} />
         <Route path="/" element={(<Default />)} />
         <Route path="/modules" element={(<Modules />)} />
+        <Route path="/expandedmodule" element={(<ExpandedModule />)} />
         <Route path="/calendar" element={(<Calendar />)} />
       </Routes>
     </div>

--- a/src/components/Module.jsx
+++ b/src/components/Module.jsx
@@ -8,7 +8,7 @@ function Module({
   // attachments,
 }) {
   return (
-    <div className={styles.module}>
+    <div className={styles.card}>
       <h1>{title}</h1>
       {/* <p>{body}</p>
       <div>{attachments}</div> */}

--- a/src/pages/Example.js
+++ b/src/pages/Example.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import styles from '../styles/Example.module.css';
 
 function Example() {
   return (
-    <div>
+    <div className={styles.exampleText}>
       Example
     </div>
   );

--- a/src/pages/Example.js
+++ b/src/pages/Example.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
+import styles from '../styles/Example.module.css';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -31,7 +32,7 @@ function Example() {
 
   return profiles.map((profile) => (
     <div key={profile.id}>
-      <div>
+      <div className={styles.exampleText}>
         {profile.firstName}
       </div>
       <div>

--- a/src/pages/ExpandedModule.js
+++ b/src/pages/ExpandedModule.js
@@ -1,5 +1,5 @@
 import { React } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import styles from '../styles/Modules.module.css';
 
 function ExpandedModule() {
@@ -7,8 +7,11 @@ function ExpandedModule() {
   const { title, body, attachments } = location.state;
   return (
     <div className={styles.card}>
-      <h1>{title}</h1>
-      <p>{body}</p>
+      <Link to="/modules" className={styles.backButton}>
+        Back
+      </Link>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.body}>{body}</div>
       <div>{attachments}</div>
     </div>
   );

--- a/src/pages/ExpandedModule.js
+++ b/src/pages/ExpandedModule.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from '../styles/Modules.module.css';
+
+function ExpandedModule({
+  title,
+  body,
+  attachments,
+}) {
+  return (
+    <div key={card.id} className={styles.card}>
+      <h1>{title}</h1>
+      <p>{body}</p>
+      <div>{attachments}</div>
+    </div>
+  );
+}
+
+export default ExpandedModule;
+
+ExpandedModule.propTypes = {
+  title: PropTypes.string.isRequired,
+  body: PropTypes.string.isRequired,
+  attachments: PropTypes.string.isRequired,
+};

--- a/src/pages/ExpandedModule.js
+++ b/src/pages/ExpandedModule.js
@@ -8,7 +8,7 @@ function ExpandedModule({
   attachments,
 }) {
   return (
-    <div key={card.id} className={styles.card}>
+    <div className={styles.card}>
       <h1>{title}</h1>
       <p>{body}</p>
       <div>{attachments}</div>

--- a/src/pages/ExpandedModule.js
+++ b/src/pages/ExpandedModule.js
@@ -1,12 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import { React, useLocation } from 'react';
 import styles from '../styles/Modules.module.css';
 
-function ExpandedModule({
-  title,
-  body,
-  attachments,
-}) {
+function ExpandedModule() {
+  const location = useLocation();
+  const { title, body, attachments } = location.state;
   return (
     <div className={styles.card}>
       <h1>{title}</h1>
@@ -17,9 +14,3 @@ function ExpandedModule({
 }
 
 export default ExpandedModule;
-
-ExpandedModule.propTypes = {
-  title: PropTypes.string.isRequired,
-  body: PropTypes.string.isRequired,
-  attachments: PropTypes.string.isRequired,
-};

--- a/src/pages/Modules.js
+++ b/src/pages/Modules.js
@@ -7,22 +7,23 @@ function Modules() {
 
   useEffect(() => {
     db.collection('modules').get().then((sc) => {
-      const module = [];
+      const card = [];
       sc.forEach((doc) => {
         const data = doc.data();
         data.id = doc.id;
-        module.push(data);
+        card.push(data);
       });
-      setModules(module);
+      setModules(card);
     });
   }, []);
 
-  return modules.map((module) => (
-    <div key={module.id}>
+  return modules.map((card) => (
+    <div key={card.id}>
       <Module
-        title={module.title}
-        // body={module.body}
-        // attachments={module.attachments}
+        title={card.title}
+        <Link to="/expandedonboarding" onClick={() => <ExpandedModule title={card.title} body={card.body} attachments={card.attachments}/>} />
+        // body={card.body}
+        // attachments={card.attachments}
       />
     </div>
   ));

--- a/src/pages/Modules.js
+++ b/src/pages/Modules.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { db } from './firebase';
 import Module from '../components/Module';
 
@@ -19,12 +20,11 @@ function Modules() {
 
   return modules.map((card) => (
     <div key={card.id}>
-      <Module
-        title={card.title}
-        <Link to="/expandedonboarding" onClick={() => <ExpandedModule title={card.title} body={card.body} attachments={card.attachments}/>} />
-        // body={card.body}
-        // attachments={card.attachments}
-      />
+      <Link to="/expandedmodule" state={{ title: card.title, body: card.body, attachment: card.attachments }}>
+        <Module
+          title={card.title}
+        />
+      </Link>
     </div>
   ));
 }

--- a/src/pages/Modules.js
+++ b/src/pages/Modules.js
@@ -20,7 +20,7 @@ function Modules() {
 
   return modules.map((card) => (
     <div key={card.id}>
-      <Link to="/expandedmodule" state={{ title: card.title, body: card.body, attachments: card.attachment }}>
+      <Link to="/expandedmodule" state={{ title: card.title, body: card.body, attachments: card.attachments }}>
         <Module
           title={card.title}
         />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,8 @@ import Default from './Default';
 import MessageWall from './MessageWall';
 import Modules from './Modules';
 import Calendar from './Calendar';
+import ExpandedModule from './ExpandedModule';
 
 export {
-  Example, Default, MessageWall, Modules, Calendar,
+  Example, Default, MessageWall, Modules, Calendar, ExpandedModule,
 };

--- a/src/styles/Example.module.css
+++ b/src/styles/Example.module.css
@@ -1,0 +1,4 @@
+.exampleText {
+    color:blue;
+    font-size: larger;
+}

--- a/src/styles/Modules.module.css
+++ b/src/styles/Modules.module.css
@@ -1,3 +1,15 @@
 .card {
     border: solid;
 }
+
+.backButton {
+    border: solid;
+}
+
+.title {
+    font-size: 30px;
+}
+
+.body {
+    font-size: 20px;
+}

--- a/src/styles/Modules.module.css
+++ b/src/styles/Modules.module.css
@@ -1,3 +1,3 @@
-.module {
+.card {
     border: solid;
 }


### PR DESCRIPTION
Now, each module card is clickable and will expand to its full contents on another page.

**Next steps:**
- Get parent back button working (expanded module to previous expanded module) [Potentially doubly-linked list to go back]
- Receiving, processing, and presenting attachments correctly

**Here is what an expanded module looks like:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/52299644/204967080-833f0e92-e1d1-49af-9c10-50553123acd2.png">
