### PR TITLE
Message wall filtering bug fixed; messages should display now?

### DIFF
--- a/client/src/pages/MessageWall.jsx
+++ b/client/src/pages/MessageWall.jsx
@@ -35,20 +35,6 @@ function MessageWall({ profile }) {
     getMessagesfunc();
   }, []);
 
-  useEffect(() => {
-    const pinned = messages.filter(
-      (message) => (message.pinned && (message.serviceArea.includes(serviceArea)
-    && message.target.includes(role))),
-    );
-    const unpinned = messages.filter(
-      (message) => (!message.pinned && (message.serviceArea.includes(serviceArea)
-    && message.target.includes(role))),
-    );
-    console.log(pinned);
-    console.log(unpinned);
-    // console.log(messages);
-  }, [messages]);
-
   // this function's purpose is to update the pinned update. it first stores all the messages in a temp variable
   // so those messages aren't affected, then it goes and finds the with a correspinding id and updates that pinned
   // status. Lastly, it sets the messages state to that message.

--- a/client/src/pages/MessageWall.jsx
+++ b/client/src/pages/MessageWall.jsx
@@ -35,6 +35,20 @@ function MessageWall({ profile }) {
     getMessagesfunc();
   }, []);
 
+  useEffect(() => {
+    const pinned = messages.filter(
+      (message) => (message.pinned && (message.serviceArea.includes(serviceArea)
+    && message.target.includes(role))),
+    );
+    const unpinned = messages.filter(
+      (message) => (!message.pinned && (message.serviceArea.includes(serviceArea)
+    && message.target.includes(role))),
+    );
+    console.log(pinned);
+    console.log(unpinned);
+    // console.log(messages);
+  }, [messages]);
+
   // this function's purpose is to update the pinned update. it first stores all the messages in a temp variable
   // so those messages aren't affected, then it goes and finds the with a correspinding id and updates that pinned
   // status. Lastly, it sets the messages state to that message.
@@ -181,13 +195,13 @@ function MessageWall({ profile }) {
         <h3>Message Wall</h3>
         {messages.filter(
           (message) => (message.pinned && (message.serviceArea.includes(serviceArea)
-        && message.target.includes(role.toLowerCase()))),
+        && message.target.includes(role))),
         ).map(
           (message) => <Message key={message.id} id={message.id} title={message.title} body={message.body} pinned={message.pinned} updatePinned={updatePinned} />,
         )}
         {messages.filter(
           (message) => (!message.pinned && (message.serviceArea.includes(serviceArea)
-        && message.target.includes(role.toLowerCase()))),
+        && message.target.includes(role))),
         ).map(
           (message) => <Message key={message.id} id={message.id} title={message.title} body={message.body} pinned={message.pinned} updatePinned={updatePinned} />,
         )}


### PR DESCRIPTION
The role is stored as camel case in the message, and we were converting the role we get from profile (which is in camelcase as well) into lowercase and checking it against the role of the message, which was causing all the messages to not be shown. 