### PR TITLE
Profile bug and password 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,8 @@
     "@fullcalendar/google-calendar": "^6.1.4",
     "@fullcalendar/interaction": "^6.1.4",
     "@fullcalendar/react": "^6.1.4",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
     "@mui/material": "^5.11.7",
     "@reduxjs/toolkit": "^1.9.2",
     "@testing-library/jest-dom": "^5.16.5",

--- a/client/src/components/CalendarEventForm.jsx
+++ b/client/src/components/CalendarEventForm.jsx
@@ -100,6 +100,11 @@ CalendarEventForm.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   getCalendarRef: PropTypes.func.isRequired,
 };

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -93,6 +93,11 @@ NavBar.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   updateAppProfile: PropTypes.func.isRequired,
 };

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -133,6 +133,11 @@ Calendar.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 export default Calendar;

--- a/client/src/pages/Example.jsx
+++ b/client/src/pages/Example.jsx
@@ -54,6 +54,11 @@ Example.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 

--- a/client/src/pages/ExpandedMentee.jsx
+++ b/client/src/pages/ExpandedMentee.jsx
@@ -304,6 +304,10 @@ ExpandedMentee.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
     mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };

--- a/client/src/pages/ExpandedModule.jsx
+++ b/client/src/pages/ExpandedModule.jsx
@@ -100,6 +100,11 @@ ExpandedModule.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 export default ExpandedModule;

--- a/client/src/pages/Media.jsx
+++ b/client/src/pages/Media.jsx
@@ -224,6 +224,10 @@ Media.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
     mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };

--- a/client/src/pages/Mentees.jsx
+++ b/client/src/pages/Mentees.jsx
@@ -141,13 +141,16 @@ function Mentees({ profile, updateAppProfile }) {
 
 Mentees.propTypes = {
   profile: PropTypes.shape({
-    id: PropTypes.string.isRequired,
     firstName: PropTypes.string.isRequired,
     lastName: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
     mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   updateAppProfile: PropTypes.func.isRequired,

--- a/client/src/pages/MessageWall.jsx
+++ b/client/src/pages/MessageWall.jsx
@@ -206,6 +206,11 @@ MessageWall.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 

--- a/client/src/pages/Modules.jsx
+++ b/client/src/pages/Modules.jsx
@@ -177,6 +177,11 @@ Modules.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 export default Modules;

--- a/client/src/pages/Requests.jsx
+++ b/client/src/pages/Requests.jsx
@@ -175,6 +175,10 @@ Requests.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 

--- a/client/src/pages/Resources.jsx
+++ b/client/src/pages/Resources.jsx
@@ -96,6 +96,11 @@ Resources.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 };
 export default Resources;

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -123,6 +123,8 @@ function Signup({ updateAppProfile }) {
               image: 'https://i.pinimg.com/550x/18/b9/ff/18b9ffb2a8a791d50213a9d595c4dd52.jpg',
               approved: false,
               date: app.firebase.firestore.Timestamp.fromDate(new Date()),
+              mentees: [],
+              bio: '',
             };
             db.collection('profiles').doc().set(data);
             navigate('/unapproved');
@@ -138,6 +140,8 @@ function Signup({ updateAppProfile }) {
           google: true,
           approved: false,
           date: app.firebase.firestore.Timestamp.fromDate(new Date()),
+          mentees: [],
+          bio: '',
         };
         db.collection('profiles').doc().set(data);
         navigate('/unapproved');

--- a/client/src/pages/UserNotApproved.jsx
+++ b/client/src/pages/UserNotApproved.jsx
@@ -43,6 +43,11 @@ UserNotApproved.propTypes = {
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   updateAppProfile: PropTypes.func.isRequired,
 };

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -11,6 +11,8 @@ import { db, storage } from './firebase';
 import * as api from '../api';
 import UserIcon from '../assets/icons/user_icon.svg';
 import LocationIcon from '../assets/icons/location_icon.svg';
+import { Input, InputAdornment, IconButton } from "@material-ui/core";
+import { Visibility, VisibilityOff } from "@material-ui/icons";
 
 // Allows users to see and change their profile properties
 function UserProfile({ profile, updateAppProfile }) {
@@ -58,6 +60,7 @@ function UserProfile({ profile, updateAppProfile }) {
           role: updatedProfile.role,
           firstName: updatedProfile.firstName,
           lastName: updatedProfile.lastName,
+          bio: updatedProfile.bio,
         };
         api.updateList(payload);
         setUpdateProfileMessage('Profile Successfully Updated!');
@@ -76,6 +79,15 @@ function UserProfile({ profile, updateAppProfile }) {
 
   const uploadImage = (e) => {
     handleUpload(e.target.files[0]);
+  };
+
+  // Fxs for password visibility toggling
+  const [showPassword, setShowPassword] = useState(false);
+  const handleClickShowPassword = () => {
+    setShowPassword(!showPassword);
+  };
+  const handleMouseDownPassword = (event) => {
+    event.preventDefault();
   };
 
   return (
@@ -103,7 +115,7 @@ function UserProfile({ profile, updateAppProfile }) {
           </div>
         </div>
         <div className={styles.edit_container}>
-          {!editProfile && <button type="button" className={styles.edit_button} onClick={HandleClick}> Edit Profile </button> }
+          {!editProfile && <button type="button" className={styles.edit_button} onClick={HandleClick}> Edit Profile </button>}
           {editProfile && <button type="button" className={styles.save_button} onClick={HandleSubmit}> Save Profile </button>}
         </div>
       </div>
@@ -111,129 +123,131 @@ function UserProfile({ profile, updateAppProfile }) {
 
       <h4 className={styles.info_label}>Basic Information</h4>
       {profile && profile.firstName && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>First Name:</p>}
-        <TextField
-          sx={{
-            fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-          }}
-          disabled={!editProfile}
-          label={editProfile ? 'First Name' : ''}
-          id="firstName"
-          className={!editProfile ? styles.label : styles.label2}
-          value={updatedProfile.firstName}
-          InputProps={{
-            readOnly: !editProfile,
-          }}
-          onChange={(event) => HandleChange(event, 'firstName')}
-        />
-      </div>
+        <div className={styles.labels_container}>
+          {!editProfile && <p>First Name:</p>}
+          <TextField
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'First Name' : ''}
+            id="firstName"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.firstName}
+            InputProps={{
+              readOnly: !editProfile,
+            }}
+            onChange={(event) => HandleChange(event, 'firstName')}
+          />
+        </div>
       )}
       {profile && profile.lastName && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>Last Name:</p>}
-        <TextField
-          sx={{
-            fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-          }}
-          disabled={!editProfile}
-          label={editProfile ? 'Last Name' : ''}
-          id="lastName"
-          className={!editProfile ? styles.label : styles.label2}
-          value={updatedProfile.lastName}
-          InputProps={{
-            readOnly: !editProfile,
-          }}
-          onChange={(event) => HandleChange(event, 'lastName')}
-        />
-      </div>
+        <div className={styles.labels_container}>
+          {!editProfile && <p>Last Name:</p>}
+          <TextField
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'Last Name' : ''}
+            id="lastName"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.lastName}
+            InputProps={{
+              readOnly: !editProfile,
+            }}
+            onChange={(event) => HandleChange(event, 'lastName')}
+          />
+        </div>
       )}
       {profile && profile.email && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>Email:</p>}
-        <TextField
-          sx={{
-            fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-          }}
-          disabled={!editProfile}
-          label={editProfile ? 'Email' : ''}
-          id="email"
-          className={!editProfile ? styles.label : styles.label2}
-          value={updatedProfile.email}
-          InputProps={{
-            readOnly: !editProfile,
-          }}
-          onChange={(event) => HandleChange(event, 'email')}
-        />
-      </div>
+        <div className={styles.labels_container}>
+          {!editProfile && <p>Email:</p>}
+          <TextField
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'Email' : ''}
+            id="email"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.email}
+            InputProps={{
+              readOnly: !editProfile,
+            }}
+            onChange={(event) => HandleChange(event, 'email')}
+          />
+        </div>
       )}
 
       <h4 className={styles.info_label}>Login Information</h4>
-      {profile && profile.role && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>Role:</p>}
-        <FormControl>
-          {editProfile && <InputLabel>Role</InputLabel>}
-          <Select
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            label={editProfile ? 'Role' : ''}
-            id="role"
-            className={!editProfile ? styles.label : styles.label2}
-            defaultValue={profile.role}
-            value={updatedProfile.role}
-            disabled={!editProfile}
-            onChange={(event) => HandleChange(event, 'role')}
-          >
-            <MenuItem value="Caregiver">Caregiver</MenuItem>
-            <MenuItem value="Mentor">Mentor</MenuItem>
-            <MenuItem value="Admin">Admin</MenuItem>
-          </Select>
-        </FormControl>
-      </div>
-      )}
-      {profile && profile.serviceArea && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>Service Area:</p>}
-        <FormControl>
-          {editProfile && <InputLabel>Service Area</InputLabel>}
-          <Select
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            label={editProfile ? 'Service Area' : ''}
-            id="serviceArea"
-            className={!editProfile ? styles.label : styles.label2}
-            defaultValue={profile.serviceArea}
-            value={updatedProfile.serviceArea}
-            disabled={!editProfile}
-            onChange={(event) => HandleChange(event, 'serviceArea')}
-          >
-            <MenuItem value="AV">AV</MenuItem>
-            <MenuItem value="MS">MS</MenuItem>
-          </Select>
-        </FormControl>
-      </div>
-      )}
       {profile && profile.username && (
-      <div className={styles.labels_container}>
-        {!editProfile && <p>Username:</p>}
-        <TextField
-          sx={{
-            fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-          }}
-          disabled={!editProfile}
-          label={editProfile ? 'Username' : ''}
-          id="username"
-          className={!editProfile ? styles.label : styles.label2}
-          value={updatedProfile.username}
-          InputProps={{
-            readOnly: !editProfile,
-          }}
-          onChange={(event) => HandleChange(event, 'username')}
-        />
-      </div>
+        <div className={styles.labels_container}>
+          {!editProfile && <p>Username:</p>}
+          <TextField
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'Username' : ''}
+            id="username"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.username}
+            InputProps={{
+              readOnly: !editProfile,
+            }}
+            onChange={(event) => HandleChange(event, 'username')}
+          />
+        </div>
+      )}
+      {profile && profile.password && ( /* password */
+        <div className={styles.labels_container}>
+          {!editProfile && <p>Password:</p>}
+          <Input
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'Password' : ''}
+            id="password"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.password}
+            inputProps={{
+              readOnly: !editProfile,
+            }}
+            type={showPassword ? "text" : "password"}
+            onChange={(event) => HandleChange(event, 'password')}
+            endAdornment= {
+            <InputAdornment position="end">
+              <IconButton
+                onClick={handleClickShowPassword}
+                onMouseDown={handleMouseDownPassword}
+              >
+                {showPassword ? <Visibility /> : <VisibilityOff />}
+              </IconButton>
+            </InputAdornment>
+            }
+          />
+        </div>
+      )}
+      {profile && (
+        <div className={styles.labels_container}>
+          {!editProfile && <p>Bio:</p>}
+          <TextField
+            sx={{
+              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+            }}
+            disabled={!editProfile}
+            label={editProfile ? 'Bio' : ''}
+            id="bio"
+            className={!editProfile ? styles.label : styles.label2}
+            value={updatedProfile.bio}
+            InputProps={{
+              readOnly: !editProfile,
+            }}
+            onChange={(event) => HandleChange(event, 'bio')}
+          />
+        </div>
       )}
     </div>
   );
@@ -244,10 +258,12 @@ UserProfile.propTypes = {
     firstName: PropTypes.string.isRequired,
     lastName: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
+    password: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     serviceArea: PropTypes.string.isRequired,
     image: PropTypes.string.isRequired,
+    bio: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
   }).isRequired,
   updateAppProfile: PropTypes.func.isRequired,

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -376,6 +376,7 @@ UserProfile.propTypes = {
     bio: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     google: PropTypes.bool,
+    mentees: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   updateAppProfile: PropTypes.func.isRequired,
 };

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -186,176 +186,179 @@ function UserProfile({ profile, updateAppProfile }) {
         </div>
       </div>
       <p>{updateProfileMessage}</p>
-
-      <h4 className={styles.info_label}>Basic Information</h4>
-      {profile && profile.firstName && (
-        <div className={styles.labels_container}>
-          {!editProfile && <p>First Name:</p>}
-          <TextField
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            disabled={!editProfile}
-            label={editProfile ? 'First Name' : ''}
-            id="firstName"
-            className={!editProfile ? styles.label : styles.label2}
-            value={updatedProfile.firstName}
-            InputProps={{
-              readOnly: !editProfile,
-            }}
-            onChange={(event) => HandleChange(event, 'firstName')}
-          />
-        </div>
-      )}
-      {profile && profile.lastName && (
-        <div className={styles.labels_container}>
-          {!editProfile && <p>Last Name:</p>}
-          <TextField
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            disabled={!editProfile}
-            label={editProfile ? 'Last Name' : ''}
-            id="lastName"
-            className={!editProfile ? styles.label : styles.label2}
-            value={updatedProfile.lastName}
-            InputProps={{
-              readOnly: !editProfile,
-            }}
-            onChange={(event) => HandleChange(event, 'lastName')}
-          />
-        </div>
-      )}
-      {profile && profile.email && (
-        <div className={styles.labels_container}>
-          {!editProfile && <p>Email:</p>}
-          <TextField
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            disabled={!editProfile}
-            label={editProfile ? 'Email' : ''}
-            id="email"
-            className={!editProfile ? styles.label : styles.label2}
-            value={updatedProfile.email}
-            InputProps={{
-              readOnly: !editProfile,
-            }}
-            onChange={(event) => HandleChange(event, 'email')}
-          />
-        </div>
-      )}
-
-      <h4 className={styles.info_label}>Login Information</h4>
-      {profile && profile.username && (
-        <div className={styles.labels_container}>
-          {!editProfile && <p>Username:</p>}
-          <TextField
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            disabled={!editProfile}
-            label={editProfile ? 'Username' : ''}
-            id="username"
-            className={!editProfile ? styles.label : styles.label2}
-            value={updatedProfile.username}
-            InputProps={{
-              readOnly: !editProfile,
-            }}
-            onChange={(event) => HandleChange(event, 'username')}
-          />
-        </div>
-      )}
-      {/* Password start, old + new passwords only shows when editing */}
-      {profile && editProfile && (
-        <div>
+      <div className={styles.info_flex}>
+        <div className={styles.info_flex_left}>
+          <h4 className={styles.info_label}>Basic Information</h4>
+          {profile && profile.firstName && (
           <div className={styles.labels_container}>
+            {!editProfile && <p>First Name:</p>}
             <TextField
               sx={{
                 fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
               }}
               disabled={!editProfile}
-              label="Verify your old Password"
-              id="password"
+              label={editProfile ? 'First Name' : ''}
+              id="firstName"
               className={!editProfile ? styles.label : styles.label2}
-              value={oldPassword}
+              value={updatedProfile.firstName}
               InputProps={{
                 readOnly: !editProfile,
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      onClick={handleClickShowOldPassword}
-                      onMouseDown={handleMouseDownOldPassword}
-                      edge="end"
-                    >
-                      {showOldPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
               }}
-              type={showOldPassword ? 'text' : 'password'}
-              onChange={(event) => handleOldPasswordChange(event)}
-              onKeyDown={(ev) => {
-                if (ev.key === 'Enter') {
-                  verifyOldPasswordMatches(ev);
-                }
-              }}
+              onChange={(event) => HandleChange(event, 'firstName')}
             />
           </div>
+          )}
+          {profile && profile.lastName && (
           <div className={styles.labels_container}>
-            { /* New password */ }
+            {!editProfile && <p>Last Name:</p>}
             <TextField
               sx={{
                 fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
               }}
-              disabled={!newPasswordAllowed}
-              label="New Password"
-              id="password"
+              disabled={!editProfile}
+              label={editProfile ? 'Last Name' : ''}
+              id="lastName"
               className={!editProfile ? styles.label : styles.label2}
-              value={newPassword}
+              value={updatedProfile.lastName}
               InputProps={{
                 readOnly: !editProfile,
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      onClick={handleClickShowNewPassword}
-                      onMouseDown={handleMouseDownNewPassword}
-                      edge="end"
-                    >
-                      {showNewPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
               }}
-              type={showNewPassword ? 'text' : 'password'}
-              onChange={(event) => handleNewPasswordChange(event)}
+              onChange={(event) => HandleChange(event, 'lastName')}
+            />
+          </div>
+          )}
+          {profile && profile.email && (
+          <div className={styles.labels_container}>
+            {!editProfile && <p>Email:</p>}
+            <TextField
+              sx={{
+                fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+              }}
+              disabled={!editProfile}
+              label={editProfile ? 'Email' : ''}
+              id="email"
+              className={!editProfile ? styles.label : styles.label2}
+              value={updatedProfile.email}
+              InputProps={{
+                readOnly: !editProfile,
+              }}
+              onChange={(event) => HandleChange(event, 'email')}
+            />
+          </div>
+          )}
+
+          <h4 className={styles.info_label}>Login Information</h4>
+          {profile && profile.username && (
+          <div className={styles.labels_container}>
+            {!editProfile && <p>Username:</p>}
+            <TextField
+              sx={{
+                fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+              }}
+              disabled={!editProfile}
+              label={editProfile ? 'Username' : ''}
+              id="username"
+              className={!editProfile ? styles.label : styles.label2}
+              value={updatedProfile.username}
+              InputProps={{
+                readOnly: !editProfile,
+              }}
+              onChange={(event) => HandleChange(event, 'username')}
+            />
+          </div>
+          )}
+          {/* Password start, old + new passwords only shows when editing */}
+          {profile && editProfile && (
+          <div>
+            <div className={styles.labels_container}>
+              <TextField
+                sx={{
+                  fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+                }}
+                disabled={!editProfile}
+                label="Verify your old Password"
+                id="password"
+                className={!editProfile ? styles.label : styles.label2}
+                value={oldPassword}
+                InputProps={{
+                  readOnly: !editProfile,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={handleClickShowOldPassword}
+                        onMouseDown={handleMouseDownOldPassword}
+                        edge="end"
+                      >
+                        {showOldPassword ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+                type={showOldPassword ? 'text' : 'password'}
+                onChange={(event) => handleOldPasswordChange(event)}
+                // TODO: change this to be more intuitive or make checking instructions explicit
+                onKeyDown={(ev) => {
+                  if (ev.key === 'Enter') {
+                    verifyOldPasswordMatches(ev);
+                  }
+                }}
+              />
+            </div>
+            <div className={styles.labels_container}>
+              { /* New password */ }
+              <TextField
+                sx={{
+                  fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+                }}
+                disabled={!newPasswordAllowed}
+                label="New Password"
+                id="password"
+                className={!editProfile ? styles.label : styles.label2}
+                value={newPassword}
+                InputProps={{
+                  readOnly: !editProfile,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={handleClickShowNewPassword}
+                        onMouseDown={handleMouseDownNewPassword}
+                        edge="end"
+                      >
+                        {showNewPassword ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+                type={showNewPassword ? 'text' : 'password'}
+                onChange={(event) => handleNewPasswordChange(event)}
+              />
+            </div>
+          </div>
+          )}
+        </div>
+        {profile && (
+        <div className={styles.info_container_right}>
+          <h4 className={styles.info_label}>Bio</h4>
+          <div className={styles.labels_container}>
+            {!editProfile && <p>Bio:</p>}
+            <TextField
+              sx={{
+                fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
+              }}
+              disabled={!editProfile}
+              label={editProfile ? 'Bio' : ''}
+              id="bio"
+              className={!editProfile ? styles.label : styles.label2}
+              value={updatedProfile.bio}
+              InputProps={{
+                readOnly: !editProfile,
+              }}
+              onChange={(event) => HandleChange(event, 'bio')}
             />
           </div>
         </div>
-
-      )}
-      {profile && (
-      <div className={styles.info_container_right}>
-        <h4 className={styles.info_label}>Bio</h4>
-        <div className={styles.labels_container}>
-          {!editProfile && <p>Bio:</p>}
-          <TextField
-            sx={{
-              fieldset: { borderColor: editProfile ? '#156DBF !important' : 'transparent !important' },
-            }}
-            disabled={!editProfile}
-            label={editProfile ? 'Bio' : ''}
-            id="bio"
-            className={!editProfile ? styles.label : styles.label2}
-            value={updatedProfile.bio}
-            InputProps={{
-              readOnly: !editProfile,
-            }}
-            onChange={(event) => HandleChange(event, 'bio')}
-          />
-        </div>
+        )}
       </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Bug fixes:
- Edited profile fields to match the figure, removed extra fields
- Previously all users could update their profile to change their role but they shouldn't be able to, now they can't change their role

New password functionality:
- added old password and new password fields
- user needs to enter old password (and verify it matches) in order to be able to edit and update new password, old password is checked using bcrypt to compare the hashes
- after the old password is verified, user can update the new password by typing it in and saving profile --> the bcrypt hashed password will be uploaded to firebase
- the password fields can toggle visibility with an eye icon
- the bio field can also be updated

Testing:
- check that the bio will be updated
- check that the old password is correctly verified
- check that the new password is correctly updated
- check that the fields match what is in the figma (except the password fields which might not exist in figma yet)